### PR TITLE
Rock of Ages Client Side PR

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -1,0 +1,11 @@
+[[source]]
+url = "https://pypi.org/simple"
+verify_ssl = true
+name = "pypi"
+
+[packages]
+
+[dev-packages]
+
+[requires]
+python_version = "3.9"

--- a/src/components/ApplicationViews.jsx
+++ b/src/components/ApplicationViews.jsx
@@ -12,14 +12,24 @@ export const ApplicationViews = () => {
     const [rocksState, setRocksState] = useState([{
         id: 1,
         name: "Sample",
+        weight: 0,
         type: {
             id: 1,
             label: "Volcanic"
+        },
+        user: {
+            first_name: "Admina",
+            last_name: "Staytor"
         }
     }])
 
-    const fetchRocksFromAPI = async () => {
-        const response = await fetch("http://localhost:8000/rocks",
+    const fetchRocksFromAPI = async (showAll) => {
+        let url = "http://localhost:8000/rocks"
+
+        if (showAll !== true){
+            url = "http://localhost:8000/rocks?owner=current"
+        }
+        const response = await fetch(url,
             {
                 headers: {
                     Authorization: `Token ${JSON.parse(localStorage.getItem("rock_token")).token}`
@@ -35,9 +45,9 @@ export const ApplicationViews = () => {
             <Route path="/register" element={<Register />} />
             <Route element={<Authorized />}>
                 <Route path="/" element={<Home />} />
-                <Route path="/allrocks" element={<RockList rocks={rocksState} fetchRocks={fetchRocksFromAPI} />} />
+                <Route path="/allrocks" element={<RockList rocks={rocksState} fetchRocks={fetchRocksFromAPI} showAll={true} />} />
                 <Route path="/create" element={<RockForm fetchRocks={fetchRocksFromAPI} />} />
-                <Route path="/mine" element={<RockList rocks={rocksState} fetchRocks={fetchRocksFromAPI} />} />
+                <Route path="/mine" element={<RockList rocks={rocksState} fetchRocks={fetchRocksFromAPI} showAll={false}/>} />
             </Route>
         </Routes>
     </BrowserRouter>

--- a/src/components/RockForm.jsx
+++ b/src/components/RockForm.jsx
@@ -5,7 +5,7 @@ export const RockForm = ({ fetchRocks }) => {
     const initialRockState = {
         name: "",
         weight: 0,
-        typeId: 0
+        type_id: 0
     }
 
     const [types, changeTypes] = useState([{ id: 1, label: "Igneous" }, { id: 2, label: "Volcanic" }])

--- a/src/components/RockList.jsx
+++ b/src/components/RockList.jsx
@@ -1,13 +1,36 @@
-import { useEffect } from "react"
+import { useEffect, useSyncExternalStore } from "react"
 
-export const RockList = ({ rocks, fetchRocks }) => {
+export const RockList = ({ rocks, fetchRocks, showAll }) => {
     useEffect(() => {
-    }, [])
+        fetchRocks(showAll)
+    }, [showAll])
 
     const displayRocks = () => {
         if (rocks && rocks.length) {
             return rocks.map(rock => <div key={`key-${rock.id}`} className="border p-5 border-solid hover:bg-fuchsia-500 hover:text-violet-50 rounded-md border-violet-900 mt-5 bg-slate-50">
-                {rock.name} ({rock.type.label})
+                <div> {rock.name} ({rock.type.label}) weighs {rock.weight}</div>
+                <div> In the collection of {rock.user.first_name} {rock.user.last_name}</div>
+                {
+                    showAll
+                        ? ""
+                        : <div>
+                        <button 
+                            onClick={async() => {
+                                const response = await fetch(`http://localhost:8000/rocks/${rock.id}`, {
+                                    method: "DELETE",
+                                    headers: {
+                                        Authorization: `Token ${JSON.parse(localStorage.getItem("rock_token")).token}`
+                                    }
+                                })
+    
+                                if (response.status === 204) {
+                                    fetchRocks(showAll)
+                                }
+                            }}
+                            className="border border-solid bg-red-700 text-white p-1">Delete</button>
+                    </div>
+                }
+                
             </div>)
         }
 


### PR DESCRIPTION
# The whole front end is now functional and all supported methods work (GET, POST, and DELETE)
## Rocks fetch call is now adjusted depending on whether you're at `/allrocks` or `/mine` using a prop called showAll 

**New Supported Routes for GET**
1. `/rocks` accessed via the [ All Rocks ] page
2. `/rocks?owner=current` accessed via the [ My Rocks ] page

**POST from the Rock form is now functioning correctly**
Fixed a variable name issue that caused to many variables to be monitored in state. typeId was changed to type_id and this matches the db so it works now. Fixes form issue

**DELETE now works too, and is User specific, so the delete buttons are only found at `/mine`**
This functionality is the reason for the new showAll variable that is passed down as a prop from ApplicationViews. By default is is true for `/allrocks` and is false for `/mine` which allows for the necessary conditional statements to both filter the rocks by User, and to only render the delete buttons in the `/mine` route.

## STEPS TO TEST

1. Pull down the `clientchapter` branch and switch to it
2.  **This test assumes you have the api repo pulled as well and the server running on port 8000, if you haven't done that go to the rock of ages api repo first**
3. Start the Vite development server by running the command `npm run dev`
4. Open your browser and go to the link shown in terminal when the run command is given ex. `http://localhost:5173`
5. Login with your credentials, or register if you haven't done so before.
6. You should now be on the Rocks of Ages home page. Click on the [ All Rocks ] button in the Nav Bar
7. This should open a list of all the rocks in the database from all users. 
8. Now click on the [ Collect a Rock ] button, and fill out the form to add a new rock, when you click 'Submit' you should navigate back to [ All Rocks ] and you should see the new rock collected.
9. Now click on [ My Rocks ], and a filtered lists of only the current Users rocks should be displayed. Additionally, they should all have [DELETE] buttons that are functional.
10. Pick your new test Rock and click its [DELETE] button and you should see the delete happen in your network tab, and the list of User rocks should reflect the deletion and be one item shorter.


